### PR TITLE
Fix git and api calls

### DIFF
--- a/e2xauthoring/models/pool.py
+++ b/e2xauthoring/models/pool.py
@@ -22,7 +22,7 @@ class Pool(Observer):
         self.name = name
         self.base_path = base_path
         self.path = os.path.join(base_path, name)
-        self.repo = GitRepoFactory.get_instance(self.path)
+        self.repo = GitRepoFactory.get_instance(os.path.realpath(self.path))
         self.repo.attach(self)
         self._is_version_controlled = self.repo.is_version_controlled
         self.tasks = self.init_tasks()
@@ -68,7 +68,7 @@ class Pool(Observer):
         self.repo.update_status()
 
     def turn_into_repository(self):
-        self.repo = GitRepoFactory.get_instance(self.path)
+        self.repo = GitRepoFactory.get_instance(os.path.realpath(self.path))
         self.repo.attach(self)
         self.repo.initialize_repo(exist_ok=True, author=Actor(**get_author()))
 

--- a/e2xauthoring/models/pool.py
+++ b/e2xauthoring/models/pool.py
@@ -65,6 +65,11 @@ class Pool(Observer):
         os.rename(self.path, new_path)
         self.name = new_name
         self.path = new_path
+
+        self.repo = GitRepoFactory.get_instance(os.path.realpath(self.path))
+        for task in self.tasks.values():
+            task.repo = self.repo
+
         self.repo.update_status()
 
     def turn_into_repository(self):

--- a/e2xauthoring/models/pool.py
+++ b/e2xauthoring/models/pool.py
@@ -21,8 +21,8 @@ class Pool(Observer):
     def __init__(self, name: str, base_path: str):
         self.name = name
         self.base_path = base_path
-        self.path = os.path.join(base_path, name)
-        self.repo = GitRepoFactory.get_instance(os.path.realpath(self.path))
+        self.path = os.path.realpath(os.path.join(base_path, name))
+        self.repo = GitRepoFactory.get_instance(self.path)
         self.repo.attach(self)
         self._is_version_controlled = self.repo.is_version_controlled
         self.tasks = self.init_tasks()
@@ -66,14 +66,14 @@ class Pool(Observer):
         self.name = new_name
         self.path = new_path
 
-        self.repo = GitRepoFactory.get_instance(os.path.realpath(self.path))
+        self.repo = GitRepoFactory.get_instance(self.path)
         for task in self.tasks.values():
             task.repo = self.repo
 
         self.repo.update_status()
 
     def turn_into_repository(self):
-        self.repo = GitRepoFactory.get_instance(os.path.realpath(self.path))
+        self.repo = GitRepoFactory.get_instance(self.path)
         self.repo.attach(self)
         self.repo.initialize_repo(exist_ok=True, author=Actor(**get_author()))
 

--- a/e2xauthoring/models/task.py
+++ b/e2xauthoring/models/task.py
@@ -4,7 +4,12 @@ import time
 from typing import Dict
 
 import nbformat
-from e2xcore.utils.nbgrader_cells import get_points, is_grade, new_read_only_cell
+from e2xcore.utils.nbgrader_cells import (
+    get_points,
+    is_grade,
+    is_nbgrader_cell,
+    new_read_only_cell,
+)
 from jupyter_client.kernelspec import KernelSpecManager
 
 from ..dataclasses import GitStatus, TaskRecord
@@ -125,7 +130,7 @@ class Task(Observer):
         notebook_path = os.path.join(path, f"{new_name}.ipynb")
         nb = nbformat.read(notebook_path, as_version=nbformat.NO_CONVERT)
         for cell in nb.cells:
-            if is_grade(cell):
+            if is_nbgrader_cell(cell):
                 cell.source = cell.source.replace(old_name, new_name)
                 cell.metadata.nbgrader.grade_id = (
                     cell.metadata.nbgrader.grade_id.replace(old_name, new_name)

--- a/e2xauthoring/models/task.py
+++ b/e2xauthoring/models/task.py
@@ -58,7 +58,7 @@ class Task(Observer):
     def __init__(self, name: str, pool: str, base_path: str, repo: GitRepo):
         self.name = name
         self.pool = pool
-        self.path = os.path.join(base_path, pool, name)
+        self.path = os.path.realpath(os.path.join(base_path, pool, name))
         self.base_path = base_path
         self.repo = repo
         self.repo.attach(self)

--- a/packages/api/src/api.js
+++ b/packages/api/src/api.js
@@ -52,16 +52,16 @@ export const API = {
         name: name,
         init_repository: init_repository,
       }),
-    rename: (name, new_name) =>
+    rename: (old_name, new_name) =>
       requests.put(POOL_API_ROOT, {
         action: "rename",
-        old_name: old_name,
+        name: old_name,
         new_name: new_name,
       }),
-    copy: (name, new_name) =>
+    copy: (old_name, new_name) =>
       requests.put(POOL_API_ROOT, {
         action: "copy",
-        old_name: old_name,
+        name: old_name,
         new_name: new_name,
       }),
     turn_into_repository: (pool) =>

--- a/packages/api/src/api.js
+++ b/packages/api/src/api.js
@@ -52,13 +52,13 @@ export const API = {
         name: name,
         init_repository: init_repository,
       }),
-    rename: (old_name, new_name) =>
+    rename: (name, new_name) =>
       requests.put(POOL_API_ROOT, {
         action: "rename",
         old_name: old_name,
         new_name: new_name,
       }),
-    copy: (old_name, new_name) =>
+    copy: (name, new_name) =>
       requests.put(POOL_API_ROOT, {
         action: "copy",
         old_name: old_name,

--- a/packages/app/src/components/alerts/GitAuthorNotSetAlert.jsx
+++ b/packages/app/src/components/alerts/GitAuthorNotSetAlert.jsx
@@ -10,6 +10,9 @@ export default function GitAuthorNotSetAlert() {
       setAuthorIsSet(!!author);
     });
   }, []);
+  const handleAuthorSet = () => {
+    setAuthorIsSet(true);
+  };
   return (
     <>
       {authorIsSet ? (
@@ -17,7 +20,7 @@ export default function GitAuthorNotSetAlert() {
       ) : (
         <Alert severity="warning">
           <AlertTitle>Git Author is not set</AlertTitle>
-          <SetGitAuthorDialog />
+          <SetGitAuthorDialog onAuthorSet={handleAuthorSet} />
         </Alert>
       )}
     </>

--- a/packages/app/src/components/dialogs/SetGitAuthorDialog.jsx
+++ b/packages/app/src/components/dialogs/SetGitAuthorDialog.jsx
@@ -9,7 +9,7 @@ import API from "@e2xauthoring/api";
 import { FormDialogWithoutButton } from "./form-dialogs";
 import { FormikTextField } from "../forms/form-components";
 
-export default function SetGitAuthorDialog() {
+export default function SetGitAuthorDialog({ onAuthorSet }) {
   const [open, setOpen] = React.useState(false);
   const formik = useFormik({
     initialValues: {
@@ -24,11 +24,13 @@ export default function SetGitAuthorDialog() {
       email: yup.string().email().required(),
     }),
     onSubmit: (values) => {
-      API.git.setAuthor(values.name, values.email).then((res) => {
+      console.log(values);
+      API.git_author.set(values.name, values.email).then((res) => {
         if (!res["success"]) {
           alert(res["message"]);
         } else {
           setOpen(false);
+          onAuthorSet();
         }
       });
     },


### PR DESCRIPTION
This pull request includes several changes to the `e2xauthoring` and `packages` directories to improve path handling, refactor code, and enhance functionality. The most important changes include updating path handling to use `os.path.realpath`, refactoring the `Task` class, and adding a callback to the `SetGitAuthorDialog` component.

### Path Handling Improvements:
* [`e2xauthoring/models/pool.py`](diffhunk://#diff-64ef3d0ef7ab0b016a5f026002176dd3821d313318aa82b1b75037c0db3c38a8L24-R24): Updated the `path` attribute in the `Pool` class to use `os.path.realpath` for resolving the absolute path.
* [`e2xauthoring/models/task.py`](diffhunk://#diff-b260264785f8b7447a03a81d1c74557e8828e4728651ccd61ffe8ed116d42ef6L56-R61): Updated the `path` attribute in the `Task` class to use `os.path.realpath` for resolving the absolute path.

### Refactoring:
* [`e2xauthoring/models/task.py`](diffhunk://#diff-b260264785f8b7447a03a81d1c74557e8828e4728651ccd61ffe8ed116d42ef6L120-R145): Refactored the `copy` method in the `Task` class to use a new `_rename_notebook` helper method for renaming notebooks.

### API Changes:
* [`packages/api/src/api.js`](diffhunk://#diff-32da8cb2eaa47dfa843abec5529844c3b70ca2a7e0db327ead5c57ad6c50b4eaL58-R64): Modified the `rename` and `copy` methods in the `API` object to change the parameter name from `old_name` to `name`.

### Component Enhancements:
* [`packages/app/src/components/alerts/GitAuthorNotSetAlert.jsx`](diffhunk://#diff-03faa1081c42a2bedb80f2a24d8951a49bb11c3f2b7517f22773bd8ad95b0a99R13-R23): Added a new `handleAuthorSet` function to update the state when the Git author is set.
* [`packages/app/src/components/dialogs/SetGitAuthorDialog.jsx`](diffhunk://#diff-ebb6212b77cebf103164282e4f8860bfc6437ef8de71ee268c042009f3dd42a0L12-R12): Added an `onAuthorSet` callback to the `SetGitAuthorDialog` component to notify when the Git author is set. [[1]](diffhunk://#diff-ebb6212b77cebf103164282e4f8860bfc6437ef8de71ee268c042009f3dd42a0L12-R12) [[2]](diffhunk://#diff-ebb6212b77cebf103164282e4f8860bfc6437ef8de71ee268c042009f3dd42a0L27-R33)